### PR TITLE
Fix when Helm provider ignores FAILED release state

### DIFF
--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -31,7 +31,7 @@ func TestAccResourceRelease_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.name", "test-basic"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.namespace", testNamespace),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.chart", "mariadb"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
 			),
@@ -40,7 +40,7 @@ func TestAccResourceRelease_basic(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 			),
 		}},
 	})
@@ -80,14 +80,14 @@ func TestAccResourceRelease_update(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 			),
 		}, {
 			Config: testAccHelmReleaseConfigBasic(testResourceName, testNamespace, "test-update", "0.6.3"),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.3"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 			),
 		}},
 	})
@@ -103,7 +103,7 @@ func TestAccResourceRelease_emptyValuesList(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "{}\n"),
 			),
 		}},
@@ -121,7 +121,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.4.1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: bar\n"),
 			),
 		}, {
@@ -131,7 +131,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.4.1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: baz\n"),
 			),
 		}},
@@ -149,7 +149,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: bar\n"),
 			),
 		}, {
@@ -159,7 +159,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.values", "foo: baz\n"),
 			),
 		}},
@@ -173,14 +173,14 @@ func TestAccResourceRelease_repository(t *testing.T) {
 			Config: testAccHelmReleaseConfigRepository(testNamespace, testResourceName),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
 			),
 		}, {
 			Config: testAccHelmReleaseConfigRepository(testNamespace, testResourceName),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
 			),
 		}},
@@ -194,7 +194,7 @@ func TestAccResourceRelease_repository_url(t *testing.T) {
 			Config: testAccHelmReleaseConfigRepositoryURL(testNamespace, testResourceName),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "version"),
 			),
@@ -202,7 +202,7 @@ func TestAccResourceRelease_repository_url(t *testing.T) {
 			Config: testAccHelmReleaseConfigRepositoryURL(testNamespace, testResourceName),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "metadata.0.version"),
 				resource.TestCheckResourceAttrSet("helm_release.test", "version"),
 			),
@@ -234,7 +234,7 @@ func TestAccResourceRelease_updateAfterFail(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.3"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 			),
 		}},
 	})
@@ -261,7 +261,7 @@ func TestAccResourceRelease_updateVersionFromRelease(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.2"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "version", "0.6.2"),
 			),
 		}, {
@@ -275,7 +275,7 @@ func TestAccResourceRelease_updateVersionFromRelease(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.version", "0.6.3"),
-				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.status", "DEPLOYED"),
+				resource.TestCheckResourceAttr("helm_release.test", "status", "DEPLOYED"),
 				resource.TestCheckResourceAttr("helm_release.test", "version", "0.6.3"),
 			),
 		}},

--- a/helm/resource_release_test.go
+++ b/helm/resource_release_test.go
@@ -99,7 +99,7 @@ func TestAccResourceRelease_emptyValuesList(t *testing.T) {
 		CheckDestroy: testAccCheckHelmReleaseDestroy,
 		Steps: []resource.TestStep{{
 			Config: testAccHelmReleaseConfigValues(
-				testResourceName, testNamespace, "test-empty-values-list", []string{""},
+				testResourceName, testNamespace, "test-empty-values-list", "stable/kibana", []string{""},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
@@ -116,7 +116,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 		CheckDestroy: testAccCheckHelmReleaseDestroy,
 		Steps: []resource.TestStep{{
 			Config: testAccHelmReleaseConfigValues(
-				testResourceName, testNamespace, "test-update-values", []string{"foo: bar"},
+				testResourceName, testNamespace, "test-update-values", "stable/kibana", []string{"foo: bar"},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
@@ -126,7 +126,7 @@ func TestAccResourceRelease_updateValues(t *testing.T) {
 			),
 		}, {
 			Config: testAccHelmReleaseConfigValues(
-				testResourceName, testNamespace, "test-update-values", []string{"foo: baz"},
+				testResourceName, testNamespace, "test-update-values", "stable/kibana", []string{"foo: baz"},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
@@ -145,7 +145,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 		Steps: []resource.TestStep{{
 			Config: testAccHelmReleaseConfigValues(
 				testResourceName, testNamespace, "test-update-multiple-values",
-				[]string{"foo: bar"},
+				"stable/kibana", []string{"foo: bar"},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "1"),
@@ -155,7 +155,7 @@ func TestAccResourceRelease_updateMultipleValues(t *testing.T) {
 		}, {
 			Config: testAccHelmReleaseConfigValues(
 				testResourceName, testNamespace, "test-update-multiple-values",
-				[]string{"foo: bar", "foo: baz"},
+				"stable/kibana", []string{"foo: bar", "foo: baz"},
 			),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("helm_release.test", "metadata.0.revision", "2"),
@@ -303,7 +303,7 @@ func testAccHelmReleaseConfigBasic(resource, ns, name, version string) string {
 	`, resource, name, ns, version)
 }
 
-func testAccHelmReleaseConfigValues(resource, ns, name string, values []string) string {
+func testAccHelmReleaseConfigValues(resource, ns, name, chart string, values []string) string {
 	vals := make([]string, len(values))
 	for i, v := range values {
 		vals[i] = strconv.Quote(v)
@@ -312,10 +312,10 @@ func testAccHelmReleaseConfigValues(resource, ns, name string, values []string) 
 		resource "helm_release" "%s" {
  			name      = %q
 			namespace = %q
-  			chart     = "stable/kibana"
+			chart     = %q
 			values    = [ %s ]
 		}
-	`, resource, name, ns, strings.Join(vals, ","))
+	`, resource, name, ns, chart, strings.Join(vals, ","))
 }
 
 func TestGetValues(t *testing.T) {


### PR DESCRIPTION
This moves status field to non-computed field in order to track state of Helm release and enforce that the state is `DEPLOYED`.

This fixes behavior when Terraform would ignore previously created release that is in FAILED state and failed to try to bring it to the desired state (assuming this will always be `DEPLOYED`)

See https://github.com/terraform-providers/terraform-provider-helm/issues/159 for more detail.

This now has tests, ready to be reviewed. To run the integration tests:
- you need to have kube cluster setup & `kubectl` configured (verify by running `kubectl get pods`)
- you need to have Helm installed & Helm client configured (verify by running `helm list`)
- set env variable `TF_ACC` to `true` to enable acceptance tests (`export TF_ACC=true`)
- you need to have go 1.10+ installed and this project in correct path as per Go conventions(`$GOPATH/src/github.com/terraform-providers/terraform-provider-helm`)
- you can run all the tests by running
   ```
   go test -v helm/*
   ```
   but expect some of them to fail (not related to this change),
   or just the new test for this feature by running
   ```
   go test -v -run "TestAccResourceRelease_updateExistingFailed" helm/*
   ```